### PR TITLE
Initial Work - Integrate with EBSCO KB

### DIFF
--- a/scripts/dev_submit_pkg.sh
+++ b/scripts/dev_submit_pkg.sh
@@ -173,9 +173,14 @@ RS_EBSCO_ID=`curl --header "X-Okapi-Tenant: diku" -H "Content-Type: application/
 }
 '`
 
-echo Import EBSCO Bentham Science Package
 
-EBSCO_BENTHAM_SCI_ID=`curl --header "X-Okapi-Tenant: diku" -X POST "http://localhost:8080/erm/admin/pullPackage?kb=EBSCO&vendorid=301&packageid=3707" | jq -r ".packageId"  | tr -d '\r'`
+if [ -z "$EBSCO_SANDBOX_CLIENT_ID" ]
+then
+  echo "No Ebsco API credentials set, skipping pull package"
+else
+  echo Import EBSCO Bentham Science Package
+  EBSCO_BENTHAM_SCI_ID=`curl --header "X-Okapi-Tenant: diku" -X POST "http://localhost:8080/erm/admin/pullPackage?kb=EBSCO&vendorid=301&packageid=3707" | jq -r ".packageId"  | tr -d '\r'`
+fi
 
 
 # If all goes well, you'll get a status message back. After that, try searching your subscribed titles:

--- a/service/grails-app/controllers/org/olf/AdminController.groovy
+++ b/service/grails-app/controllers/org/olf/AdminController.groovy
@@ -49,6 +49,7 @@ class AdminController {
   public pullPackage() {
     def result = [:]
     RemoteKB rkb = RemoteKB.findByName(params.kb)
+
     if ( rkb ) {
       log.debug("Located KB record -- ${rkb}");
       try {

--- a/service/grails-app/services/org/olf/PackageIngestService.groovy
+++ b/service/grails-app/services/org/olf/PackageIngestService.groovy
@@ -96,7 +96,7 @@ public class PackageIngestService {
 
               if ( ( pc.platformUrl == null ) && ( pc.url != null ) ) {
                 // No platform URL, but a URL for the title. Parse the URL and generate a platform URL
-                def parsed_url = new java.net.URL(url);
+                def parsed_url = new java.net.URL(pc.url);
                 platform_url_to_use = "${parsed_url.getProtocol()}://${parsed_url.getHost()}"
               }
 

--- a/service/grails-app/services/org/olf/TitleInstanceResolverService.groovy
+++ b/service/grails-app/services/org/olf/TitleInstanceResolverService.groovy
@@ -18,8 +18,6 @@ import org.olf.general.RefdataCategory
 @Transactional
 public class TitleInstanceResolverService {
 
-  def sessionFactory
-
   private static final String TEXT_MATCH_TITLE_QRY = 'select * from title_instance WHERE ti_title % :qrytitle AND similarity(ti_title, :qrytitle) > :threshold ORDER BY  similarity(ti_title, :qrytitle) desc LIMIT 20'
 
   private static def class_one_namespaces = [
@@ -177,23 +175,25 @@ public class TitleInstanceResolverService {
   private List<TitleInstance> titleMatch(String title) {
 
     List<TitleInstance> result = new ArrayList<TitleInstance>()
-    final session = sessionFactory.currentSession
-    final sqlQuery = session.createSQLQuery(TEXT_MATCH_TITLE_QRY)
+    TitleInstance.withSession { session ->
 
-    try {
-      result = sqlQuery.with {
-        addEntity(TitleInstance)
-        // Set query title - I know this looks a little odd, we have to manually quote this and handle any
-        // relevant escaping... So this code will probably not be good enough long term.
-        setString('qrytitle',title);
-        setFloat('threshold',0.6f)
- 
-        // Get all results.
-        list()
+      final sqlQuery = session.createSQLQuery(TEXT_MATCH_TITLE_QRY)
+
+      try {
+        result = sqlQuery.with {
+          addEntity(TitleInstance)
+          // Set query title - I know this looks a little odd, we have to manually quote this and handle any
+          // relevant escaping... So this code will probably not be good enough long term.
+          setString('qrytitle',title);
+          setFloat('threshold',0.6f)
+   
+          // Get all results.
+          list()
+        }
       }
-    }
-    catch ( Exception e ) {
-      log.error("Problem attempting to run SQL Query ${TEXT_MATCH_TITLE_QRY} on string ${title} with threshold 0.6f",e);
+      catch ( Exception e ) {
+        log.error("Problem attempting to run SQL Query ${TEXT_MATCH_TITLE_QRY} on string ${title} with threshold 0.6f",e);
+      }
     }
  
     return result


### PR DESCRIPTION
This PR enables mod-erm to import packages from EBSCO KB. This works by allowing the system to declare a RemoteKB record for EBSCO -- this is tested in dev_submit_pkg.sh with 

RS_EBSCO_ID=`curl --header "X-Okapi-Tenant: diku" -H "Content-Type: application/json" -X POST http://localhost:8080/erm/kbs -d '
{
  name:"EBSCO",
  type:"org.olf.kb.adapters.EbscoKBAdapter",
  cursor:null,
  uri:"https://sandbox.ebsco.io",
  listPrefix:null,
  principal:"'"$EBSCO_SANDBOX_CLIENT_ID"'",
  credentials:"'"$EBSCO_SANDBOX_API_KEY"'",
  rectype:"1",
  active:false,
  supportsHarvesting:false
}
'`

Things to note here: the EBSCO implementation does not support harvesting, the dev_submit_pkg.sh file now calls out to a file in the user home directory called folio_privates.sh. Developers wanting to use this functionality will need to set the EBSCO_SANDBOX_CLIENT_ID and API_KEY in that file (Get them by registering with the EBSCO API provider). This setup means we can commit this code to the public repository without fear that API keys will be shared.

Having set up a RemoteKB for EBSCO, the following call::

curl --header "X-Okapi-Tenant: diku" -X POST "http://localhost:8080/erm/admin/pullPackage?kb=EBSCO&vendorid=301&packageid=3707

Will trigger a pull of a package from EBSCO and make the contents searchable in mod-erm. Re-issuing the call on subsequent days will re-harvest the package and create deltas that record what has changed (Additions, Removals and coverage changes) since the last update.