### PR TITLE
Improve package ingest - coverage overlap detection and fuzzy match threshold

### DIFF
--- a/service/grails-app/services/org/olf/CoverageExtenderService.groovy
+++ b/service/grails-app/services/org/olf/CoverageExtenderService.groovy
@@ -47,7 +47,20 @@ public class CoverageExtenderService {
           }
         }
 
-        if ( new_coverage_is_already_subsumed ) {
+        if ( !new_coverage_is_already_subsumed ) {
+          // We need to create a new CS. For now, create as from the source - later on we will need to do something smarter
+          // where we coalesce all the statements.
+          def new_cs = new CoverageStatement();
+          // This is clever groovy script to assign a property based on that prop name being in a variable,
+          // property will be one of ti, pci or pti and this will set the appropriate one.
+          new_cs."${property}" = title
+          new_cs.startDate = cs.startDate
+          new_cs.endDate = cs.endDate
+          new_cs.startVolume = cs.startVolume
+          new_cs.startIssue = cs.startIssue
+          new_cs.endVolume = cs.endVolume
+          new_cs.endIssue = cs.endIssue
+          new_cs.save(flush:true, failOnError:true);
         }
       }
       else {

--- a/service/grails-app/services/org/olf/TitleInstanceResolverService.groovy
+++ b/service/grails-app/services/org/olf/TitleInstanceResolverService.groovy
@@ -18,6 +18,7 @@ import org.olf.general.RefdataCategory
 @Transactional
 public class TitleInstanceResolverService {
 
+  private static final float MATCH_THRESHOLD = 0.75f;
   private static final String TEXT_MATCH_TITLE_QRY = 'select * from title_instance WHERE ti_title % :qrytitle AND similarity(ti_title, :qrytitle) > :threshold ORDER BY  similarity(ti_title, :qrytitle) desc LIMIT 20'
 
   private static def class_one_namespaces = [
@@ -51,7 +52,7 @@ public class TitleInstanceResolverService {
    *   }
    */
   public TitleInstance resolve(Map citation) {
-    log.debug("TitleInstanceResolverService::resolve(${citation})");
+    // log.debug("TitleInstanceResolverService::resolve(${citation})");
     TitleInstance result = null;
 
     List<TitleInstance> candidate_list = classOneMatch(citation.instanceIdentifiers);
@@ -59,25 +60,25 @@ public class TitleInstanceResolverService {
     int num_matches = candidate_list.size()
 
     if ( num_matches == 0 ) {
-      log.debug("No matches on identifier - try a fuzzy text match on title(${citation.title})");
+      // log.debug("No matches on identifier - try a fuzzy text match on title(${citation.title})");
       // No matches - try a simple title match
-      candidate_list = titleMatch(citation.title);
+      candidate_list = titleMatch(citation.title,MATCH_THRESHOLD);
       num_matches = candidate_list.size()
     }
 
     if ( candidate_list != null ) {
       switch ( num_matches ) {
         case(0):
-          log.debug("No title match");
+          // log.debug("No title match");
           result = createNewTitleInstance(citation);
           break;
         case(1):
-          log.debug("Exact match.");
+          // log.debug("Exact match.");
           result = candidate_list.get(0);
           checkForEnrichment(result, citation);
           break;
         default:
-          log.error("title matched {num_matches} records. Unable to continue. Matching IDs: ${candidate_list.collect { it.id }}");
+          log.warn("title matched ${num_matches} records with a threshold >= ${MATCH_THRESHOLD} . Unable to continue. Matching IDs: ${candidate_list.collect { it.id }}");
           // throw new RuntimeException("Title match returned too many items (${num_matches})");
           break;
       }
@@ -172,7 +173,7 @@ public class TitleInstanceResolverService {
   /**
    * Attempt a fuzzy match on the title
    */
-  private List<TitleInstance> titleMatch(String title) {
+  private List<TitleInstance> titleMatch(String title, float threshold) {
 
     List<TitleInstance> result = new ArrayList<TitleInstance>()
     TitleInstance.withSession { session ->
@@ -185,7 +186,7 @@ public class TitleInstanceResolverService {
           // Set query title - I know this looks a little odd, we have to manually quote this and handle any
           // relevant escaping... So this code will probably not be good enough long term.
           setString('qrytitle',title);
-          setFloat('threshold',0.6f)
+          setFloat('threshold',threshold)
    
           // Get all results.
           list()
@@ -215,7 +216,7 @@ public class TitleInstanceResolverService {
         num_class_one_identifiers++;
 
         // Look up each identifier
-        log.debug("${id} - try class one match");
+        // log.debug("${id} - try class one match");
         def id_matches = Identifier.executeQuery('select id from Identifier as id where id.value = :value and id.ns.value = :ns',[value:id.value, ns:id.namespace])
 
         assert ( id_matches.size() <= 1 )
@@ -229,7 +230,7 @@ public class TitleInstanceResolverService {
                 // We have already seen this title, so don't add it again
               }
               else {
-                log.debug("Adding title ${io.title.id} ${io.title.title} to matches for ${matched_id}");
+                // log.debug("Adding title ${io.title.id} ${io.title.title} to matches for ${matched_id}");
                 result << io.title
               }
             }
@@ -240,11 +241,11 @@ public class TitleInstanceResolverService {
         }
       }
       else {
-        log.debug("Identifier ${id} not from a class one namespace");
+        // log.debug("Identifier ${id} not from a class one namespace");
       }
     }
 
-    log.debug("At end of classOneMatch, resut contains ${result.size()} titles");
+    // log.debug("At end of classOneMatch, resut contains ${result.size()} titles");
     return result;
   }
 }

--- a/service/grails-app/services/org/olf/TitleInstanceResolverService.groovy
+++ b/service/grails-app/services/org/olf/TitleInstanceResolverService.groovy
@@ -57,9 +57,12 @@ public class TitleInstanceResolverService {
 
     List<TitleInstance> candidate_list = classOneMatch(citation.instanceIdentifiers);
 
+    int num_class_one_identifiers = countClassOneIDs(citation.instanceIdentifiers);
+
     int num_matches = candidate_list.size()
 
-    if ( num_matches == 0 ) {
+    // If we didn't have a class one identifier AND we weren't able to match anything try to do a fuzzy match as a last resort
+    if ( ( num_matches == 0 ) && ( num_class_one_identifiers == 0 ) ) {
       // log.debug("No matches on identifier - try a fuzzy text match on title(${citation.title})");
       // No matches - try a simple title match
       candidate_list = titleMatch(citation.title,MATCH_THRESHOLD);
@@ -198,6 +201,16 @@ public class TitleInstanceResolverService {
     }
  
     return result
+  }
+
+  private int countClassOneIDs(List identifiers) {
+    int result = 0;
+    identifiers.each { id ->
+      if ( class_one_namespaces?.contains(id.namespace.toLowerCase()) ) {
+        result++;
+      }
+    }
+    return result;
   }
 
   /**


### PR DESCRIPTION
Tighten up the rules on coverage overlap detection and when to use a fuzzy match after an identifier match fails.