### PR TITLE
Add reference or Org (proxy for vendor)

### DIFF
--- a/scripts/eresources.sh
+++ b/scripts/eresources.sh
@@ -1,1 +1,1 @@
-curl --header "X-Okapi-Tenant: diku" http://localhost:8080/erm/eresources -X GET
+curl --header "X-Okapi-Tenant: diku" http://localhost:8080/erm/resource/electronic -X GET

--- a/service/grails-app/domain/org/olf/general/Org.groovy
+++ b/service/grails-app/domain/org/olf/general/Org.groovy
@@ -9,6 +9,7 @@ class Org implements MultiTenant<Org> {
   String id
   String name
   String vendorsUuid
+  String reference
 
   // IF this resource is controlled by another service,
   // what is the URI of the primary resource
@@ -21,11 +22,34 @@ class Org implements MultiTenant<Org> {
           name column: 'org_name'
    vendorsUuid column: 'org_vendors_uuid'
      sourceURI column: 'org_source_uri'
+     reference column: 'org_reference'
   }
 
   static constraints = {
-    sourceURI(nullable:true, blank:false)
+      sourceURI(nullable:true, blank:false)
     vendorsUuid(nullable:true, blank:false)
+      reference(nullable:true, blank:false)
+
   }
 
+  /**
+   * In many places we will look up an org and in the context of that lookup we may know something
+   * extra about the org we are looking up. This method checks a known list of properties and if not set
+   * will absorb any extra context into the record. This is used to accumulate external identifers and
+   * other contextual information.
+   */
+  public void enrich(Map<String, Object> props) {
+    boolean changed = false;
+    props.keySet().each { k -> 
+      if ( ( props[k] != null ) && ( [ 'reference'].contains(k) ) ) {
+        if ( this[k] == null ) {
+          this[k] = props[k]
+        }
+      }
+    }
+
+    if ( changed ) {
+      this.save(flush:true, failOnError);
+    }
+  }
 }

--- a/service/grails-app/domain/org/olf/kb/ContentActivationRecord.groovy
+++ b/service/grails-app/domain/org/olf/kb/ContentActivationRecord.groovy
@@ -25,7 +25,7 @@ public class ContentActivationRecord implements MultiTenant<ContentActivationRec
   ]
 
   static mapping = {
-           table 'content_activation_target'
+           table 'content_activation_record'
                   id column: 'car_id', generator: 'uuid', length:36
              version column: 'car_version'
       dateActivation column: 'car_date_activation'

--- a/service/grails-app/migrations/initial-model.groovy
+++ b/service/grails-app/migrations/initial-model.groovy
@@ -1,7 +1,7 @@
 databaseChangeLog = {
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-1") {
-        createTable(tableName: "content_activation_target") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-1") {
+        createTable(tableName: "content_activation_record") {
             column(name: "car_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
             }
@@ -28,7 +28,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-2") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-2") {
         createTable(tableName: "coverage_statement") {
             column(name: "cs_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -58,7 +58,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-3") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-3") {
         createTable(tableName: "entitlement") {
             column(name: "ent_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -82,7 +82,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-4") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-4") {
         createTable(tableName: "erm_resource") {
             column(name: "id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -100,7 +100,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-5") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-5") {
         createTable(tableName: "holdings_coverage") {
             column(name: "co_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -126,7 +126,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-6") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-6") {
         createTable(tableName: "identifier") {
             column(name: "id_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -146,7 +146,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-7") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-7") {
         createTable(tableName: "identifier_namespace") {
             column(name: "idns_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -162,7 +162,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-8") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-8") {
         createTable(tableName: "identifier_occurrence") {
             column(name: "io_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -184,7 +184,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-9") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-9") {
         createTable(tableName: "internal_contact") {
             column(name: "ic_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -208,7 +208,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-10") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-10") {
         createTable(tableName: "node") {
             column(name: "nd_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -238,7 +238,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-11") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-11") {
         createTable(tableName: "org") {
             column(name: "org_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -258,7 +258,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-12") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-12") {
         createTable(tableName: "package") {
             column(name: "id", type: "VARCHAR(255)") {
                 constraints(nullable: "false")
@@ -280,7 +280,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-13") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-13") {
         createTable(tableName: "package_content_item") {
             column(name: "id", type: "VARCHAR(255)") {
                 constraints(nullable: "false")
@@ -310,7 +310,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-14") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-14") {
         createTable(tableName: "platform") {
             column(name: "pt_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -326,7 +326,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-15") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-15") {
         createTable(tableName: "platform_locator") {
             column(name: "pl_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -346,7 +346,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-16") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-16") {
         createTable(tableName: "platform_title_instance") {
             column(name: "id", type: "VARCHAR(255)") {
                 constraints(nullable: "false")
@@ -364,7 +364,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-17") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-17") {
         createTable(tableName: "po_line_proxy") {
             column(name: "pop_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -386,7 +386,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-18") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-18") {
         createTable(tableName: "refdata_category") {
             column(name: "rdc_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -402,7 +402,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-19") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-19") {
         createTable(tableName: "refdata_value") {
             column(name: "rdv_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -426,7 +426,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-20") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-20") {
         createTable(tableName: "remotekb") {
             column(name: "rkb_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -468,7 +468,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-21") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-21") {
         createTable(tableName: "sa_event_history") {
             column(name: "eh_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -504,7 +504,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-22") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-22") {
         createTable(tableName: "subscription_agreement") {
             column(name: "sa_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -550,7 +550,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-23") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-23") {
         createTable(tableName: "title_instance") {
             column(name: "id", type: "VARCHAR(255)") {
                 constraints(nullable: "false")
@@ -560,7 +560,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-24") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-24") {
         createTable(tableName: "work") {
             column(name: "w_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -576,103 +576,103 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-25") {
-        addPrimaryKey(columnNames: "car_id", constraintName: "content_activation_targetPK", tableName: "content_activation_target")
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-25") {
+        addPrimaryKey(columnNames: "car_id", constraintName: "content_activation_recordPK", tableName: "content_activation_record")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-26") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-26") {
         addPrimaryKey(columnNames: "cs_id", constraintName: "coverage_statementPK", tableName: "coverage_statement")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-27") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-27") {
         addPrimaryKey(columnNames: "ent_id", constraintName: "entitlementPK", tableName: "entitlement")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-28") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-28") {
         addPrimaryKey(columnNames: "id", constraintName: "erm_resourcePK", tableName: "erm_resource")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-29") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-29") {
         addPrimaryKey(columnNames: "co_id", constraintName: "holdings_coveragePK", tableName: "holdings_coverage")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-30") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-30") {
         addPrimaryKey(columnNames: "id_id", constraintName: "identifierPK", tableName: "identifier")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-31") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-31") {
         addPrimaryKey(columnNames: "idns_id", constraintName: "identifier_namespacePK", tableName: "identifier_namespace")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-32") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-32") {
         addPrimaryKey(columnNames: "io_id", constraintName: "identifier_occurrencePK", tableName: "identifier_occurrence")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-33") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-33") {
         addPrimaryKey(columnNames: "ic_id", constraintName: "internal_contactPK", tableName: "internal_contact")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-34") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-34") {
         addPrimaryKey(columnNames: "nd_id", constraintName: "nodePK", tableName: "node")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-35") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-35") {
         addPrimaryKey(columnNames: "org_id", constraintName: "orgPK", tableName: "org")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-36") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-36") {
         addPrimaryKey(columnNames: "id", constraintName: "packagePK", tableName: "package")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-37") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-37") {
         addPrimaryKey(columnNames: "id", constraintName: "package_content_itemPK", tableName: "package_content_item")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-38") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-38") {
         addPrimaryKey(columnNames: "pt_id", constraintName: "platformPK", tableName: "platform")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-39") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-39") {
         addPrimaryKey(columnNames: "pl_id", constraintName: "platform_locatorPK", tableName: "platform_locator")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-40") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-40") {
         addPrimaryKey(columnNames: "id", constraintName: "platform_title_instancePK", tableName: "platform_title_instance")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-41") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-41") {
         addPrimaryKey(columnNames: "pop_id", constraintName: "po_line_proxyPK", tableName: "po_line_proxy")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-42") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-42") {
         addPrimaryKey(columnNames: "rdc_id", constraintName: "refdata_categoryPK", tableName: "refdata_category")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-43") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-43") {
         addPrimaryKey(columnNames: "rdv_id", constraintName: "refdata_valuePK", tableName: "refdata_value")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-44") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-44") {
         addPrimaryKey(columnNames: "rkb_id", constraintName: "remotekbPK", tableName: "remotekb")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-45") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-45") {
         addPrimaryKey(columnNames: "eh_id", constraintName: "sa_event_historyPK", tableName: "sa_event_history")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-46") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-46") {
         addPrimaryKey(columnNames: "sa_id", constraintName: "subscription_agreementPK", tableName: "subscription_agreement")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-47") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-47") {
         addPrimaryKey(columnNames: "id", constraintName: "title_instancePK", tableName: "title_instance")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-48") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-48") {
         addPrimaryKey(columnNames: "w_id", constraintName: "workPK", tableName: "work")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-49") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-49") {
         createIndex(indexName: "rdv_entry_idx", tableName: "refdata_value") {
             column(name: "rdv_value")
 
@@ -680,151 +680,151 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-50") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-50") {
         addForeignKeyConstraint(baseColumnNames: "io_identifier_fk", baseTableName: "identifier_occurrence", constraintName: "FK124sp9vc5hnix1ufo6wi2vbav", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id_id", referencedTableName: "identifier")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-51") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-51") {
         addForeignKeyConstraint(baseColumnNames: "cs_ti_fk", baseTableName: "coverage_statement", constraintName: "FK2ocimr1uh2pogta68xl9ph3n", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "title_instance")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-52") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-52") {
         addForeignKeyConstraint(baseColumnNames: "nd_parent", baseTableName: "node", constraintName: "FK2x99i2kqqt7g2ik5cn2fmif6t", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "nd_id", referencedTableName: "node")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-53") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-53") {
         addForeignKeyConstraint(baseColumnNames: "sa_renewal_priority", baseTableName: "subscription_agreement", constraintName: "FK34wtnrq42y7hiab2pg918y7en", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-54") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-54") {
         addForeignKeyConstraint(baseColumnNames: "sa_content_review_needed", baseTableName: "subscription_agreement", constraintName: "FK4nhteulih6q3nqtsu512ny93x", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-55") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-55") {
         addForeignKeyConstraint(baseColumnNames: "pci_pkg_fk", baseTableName: "package_content_item", constraintName: "FK4u9t780a3pgjy1wxsdn8r131k", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "package")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-56") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-56") {
         addForeignKeyConstraint(baseColumnNames: "sa_agreement_type", baseTableName: "subscription_agreement", constraintName: "FK613exmd4qa6bjjdycx9kot0yp", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-57") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-57") {
         addForeignKeyConstraint(baseColumnNames: "ti_work_fk", baseTableName: "title_instance", constraintName: "FK6jfb5y930akyqphqjt55yrga6", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "w_id", referencedTableName: "work")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-58") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-58") {
         addForeignKeyConstraint(baseColumnNames: "ic_role", baseTableName: "internal_contact", constraintName: "FK6njvotbglvhl7adk4hiv1kbsn", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-59") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-59") {
         addForeignKeyConstraint(baseColumnNames: "ic_owner_fk", baseTableName: "internal_contact", constraintName: "FK7p34rfl5q8gij3717gpkxq4yt", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "sa_id", referencedTableName: "subscription_agreement")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-60") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-60") {
         addForeignKeyConstraint(baseColumnNames: "co_ent_fk", baseTableName: "holdings_coverage", constraintName: "FK7tx1qaa6hcl1p5kg4n9k8fv4d", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "ent_id", referencedTableName: "entitlement")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-61") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-61") {
         addForeignKeyConstraint(baseColumnNames: "sa_is_perpetual", baseTableName: "subscription_agreement", constraintName: "FK8g7c4fgbop5kuy91di5eh9luq", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-62") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-62") {
         addForeignKeyConstraint(baseColumnNames: "pop_owner", baseTableName: "po_line_proxy", constraintName: "FK8ufrte3dhjhseabh067wg08lr", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "ent_id", referencedTableName: "entitlement")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-63") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-63") {
         addForeignKeyConstraint(baseColumnNames: "io_status_fk", baseTableName: "identifier_occurrence", constraintName: "FK930t3v9wtioa9a9j5013au5ci", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-64") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-64") {
         addForeignKeyConstraint(baseColumnNames: "eh_event_outcome", baseTableName: "sa_event_history", constraintName: "FK9hxymcjll2kctbwvm60j8ywxv", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-65") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-65") {
+        addForeignKeyConstraint(baseColumnNames: "car_target_kb_fk", baseTableName: "content_activation_record", constraintName: "FK9l1k430yfqn9hft2a27kvrv12", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rkb_id", referencedTableName: "remotekb")
+    }
+
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-66") {
         addForeignKeyConstraint(baseColumnNames: "ent_resource_fk", baseTableName: "entitlement", constraintName: "FK9uj3dokm2wv87kfp3vjphnc83", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "erm_resource")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-66") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-67") {
         addForeignKeyConstraint(baseColumnNames: "io_ti_fk", baseTableName: "identifier_occurrence", constraintName: "FKat7yej3qg0w5ppb0t4akj51wl", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "title_instance")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-67") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-68") {
         addForeignKeyConstraint(baseColumnNames: "id_ns_fk", baseTableName: "identifier", constraintName: "FKby5jjtajics8edtt193lwtnwv", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "idns_id", referencedTableName: "identifier_namespace")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-68") {
-        addForeignKeyConstraint(baseColumnNames: "car_pti_fk", baseTableName: "content_activation_target", constraintName: "FKbyr8417ulw3vjwb3qp3pr13c2", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "platform_title_instance")
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-69") {
+        addForeignKeyConstraint(baseColumnNames: "car_pti_fk", baseTableName: "content_activation_record", constraintName: "FKcg8khs1ip5xiibdkp85xoe7ba", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "platform_title_instance")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-69") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-70") {
         addForeignKeyConstraint(baseColumnNames: "cs_pci_fk", baseTableName: "coverage_statement", constraintName: "FKciqq54dwgdmv0ta5ugs58sn36", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "package_content_item")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-70") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-71") {
         addForeignKeyConstraint(baseColumnNames: "cs_pti_fk", baseTableName: "coverage_statement", constraintName: "FKdj82640bdcj4dfrbn0aqdgbfp", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "platform_title_instance")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-71") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-72") {
         addForeignKeyConstraint(baseColumnNames: "pti_ti_fk", baseTableName: "platform_title_instance", constraintName: "FKedoadk035beg5u3vi2232pq9m", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "title_instance")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-72") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-73") {
         addForeignKeyConstraint(baseColumnNames: "res_type_fk", baseTableName: "erm_resource", constraintName: "FKef3ae6ct52nn3jcmqidhhpwf8", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-73") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-74") {
         addForeignKeyConstraint(baseColumnNames: "eh_owner", baseTableName: "sa_event_history", constraintName: "FKeopwa26u1tipqav4a0y01i9sr", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "sa_id", referencedTableName: "subscription_agreement")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-74") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-75") {
         addForeignKeyConstraint(baseColumnNames: "res_sub_type_fk", baseTableName: "erm_resource", constraintName: "FKfc1lm4f2parkaa8en9fmo4sqc", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-75") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-76") {
         addForeignKeyConstraint(baseColumnNames: "pl_owner_fk", baseTableName: "platform_locator", constraintName: "FKfn4ls5f77sc18cq9c8owlkgtp", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "pt_id", referencedTableName: "platform")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-76") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-77") {
         addForeignKeyConstraint(baseColumnNames: "rdv_owner", baseTableName: "refdata_value", constraintName: "FKh4fon2a7k4y8b2sicjm0i6oy8", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdc_id", referencedTableName: "refdata_category")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-77") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-78") {
         addForeignKeyConstraint(baseColumnNames: "sa_agreement_status", baseTableName: "subscription_agreement", constraintName: "FKiivriw3306iouwpg8e65t3ff0", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-78") {
-        addForeignKeyConstraint(baseColumnNames: "car_target_kb_fk", baseTableName: "content_activation_target", constraintName: "FKj7orcapekjyxir8xukrynibc4", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rkb_id", referencedTableName: "remotekb")
-    }
-
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-79") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-79") {
         addForeignKeyConstraint(baseColumnNames: "pkg_remote_kb", baseTableName: "package", constraintName: "FKoedx99aeb9ll9v1p7w29htqtl", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rkb_id", referencedTableName: "remotekb")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-80") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-80") {
         addForeignKeyConstraint(baseColumnNames: "pkg_vendor_fk", baseTableName: "package", constraintName: "FKokps4xbl6ipd7unkfq910jn03", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "org_id", referencedTableName: "org")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-81") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-81") {
         addForeignKeyConstraint(baseColumnNames: "ent_owner_fk", baseTableName: "entitlement", constraintName: "FKoocrauwiw6xp7ace0yueywgqy", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "sa_id", referencedTableName: "subscription_agreement")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-82") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-82") {
         addForeignKeyConstraint(baseColumnNames: "pci_pti_fk", baseTableName: "package_content_item", constraintName: "FKostrwqec52cid7enxbr4b2loe", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "platform_title_instance")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-83") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-83") {
         addForeignKeyConstraint(baseColumnNames: "sa_vendor_fk", baseTableName: "subscription_agreement", constraintName: "FKppeugnj4xts3ah8tjmeg232db", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "org_id", referencedTableName: "org")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-84") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-84") {
         addForeignKeyConstraint(baseColumnNames: "eh_event_type", baseTableName: "sa_event_history", constraintName: "FKs8nxucxkesrpshhxsh15wxdn0", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-85") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-85") {
         addForeignKeyConstraint(baseColumnNames: "pkg_nominal_platform_fk", baseTableName: "package", constraintName: "FKtji5rpd3emxprdidedl006f9u", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "pt_id", referencedTableName: "platform")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539513591756-86") {
+    changeSet(author: "ianibbo (generated)", id: "1539514444652-86") {
         addForeignKeyConstraint(baseColumnNames: "pti_pt_fk", baseTableName: "platform_title_instance", constraintName: "FKtlecp40x0sb3rd9w4qi16lcu0", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "pt_id", referencedTableName: "platform")
     }
 }

--- a/service/grails-app/migrations/initial-model.groovy
+++ b/service/grails-app/migrations/initial-model.groovy
@@ -1,6 +1,6 @@
 databaseChangeLog = {
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-1") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-1") {
         createTable(tableName: "content_activation_record") {
             column(name: "car_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -28,7 +28,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-2") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-2") {
         createTable(tableName: "coverage_statement") {
             column(name: "cs_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -58,7 +58,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-3") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-3") {
         createTable(tableName: "entitlement") {
             column(name: "ent_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -82,7 +82,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-4") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-4") {
         createTable(tableName: "erm_resource") {
             column(name: "id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -100,7 +100,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-5") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-5") {
         createTable(tableName: "holdings_coverage") {
             column(name: "co_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -126,7 +126,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-6") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-6") {
         createTable(tableName: "identifier") {
             column(name: "id_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -146,7 +146,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-7") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-7") {
         createTable(tableName: "identifier_namespace") {
             column(name: "idns_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -162,7 +162,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-8") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-8") {
         createTable(tableName: "identifier_occurrence") {
             column(name: "io_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -184,7 +184,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-9") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-9") {
         createTable(tableName: "internal_contact") {
             column(name: "ic_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -208,7 +208,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-10") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-10") {
         createTable(tableName: "node") {
             column(name: "nd_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -238,7 +238,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-11") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-11") {
         createTable(tableName: "org") {
             column(name: "org_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -255,10 +255,12 @@ databaseChangeLog = {
             }
 
             column(name: "org_source_uri", type: "VARCHAR(255)")
+
+            column(name: "org_reference", type: "VARCHAR(255)")
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-12") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-12") {
         createTable(tableName: "package") {
             column(name: "id", type: "VARCHAR(255)") {
                 constraints(nullable: "false")
@@ -280,7 +282,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-13") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-13") {
         createTable(tableName: "package_content_item") {
             column(name: "id", type: "VARCHAR(255)") {
                 constraints(nullable: "false")
@@ -310,7 +312,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-14") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-14") {
         createTable(tableName: "platform") {
             column(name: "pt_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -326,7 +328,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-15") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-15") {
         createTable(tableName: "platform_locator") {
             column(name: "pl_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -346,7 +348,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-16") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-16") {
         createTable(tableName: "platform_title_instance") {
             column(name: "id", type: "VARCHAR(255)") {
                 constraints(nullable: "false")
@@ -364,7 +366,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-17") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-17") {
         createTable(tableName: "po_line_proxy") {
             column(name: "pop_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -386,7 +388,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-18") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-18") {
         createTable(tableName: "refdata_category") {
             column(name: "rdc_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -402,7 +404,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-19") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-19") {
         createTable(tableName: "refdata_value") {
             column(name: "rdv_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -426,7 +428,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-20") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-20") {
         createTable(tableName: "remotekb") {
             column(name: "rkb_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -468,7 +470,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-21") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-21") {
         createTable(tableName: "sa_event_history") {
             column(name: "eh_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -504,7 +506,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-22") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-22") {
         createTable(tableName: "subscription_agreement") {
             column(name: "sa_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -550,7 +552,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-23") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-23") {
         createTable(tableName: "title_instance") {
             column(name: "id", type: "VARCHAR(255)") {
                 constraints(nullable: "false")
@@ -560,7 +562,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-24") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-24") {
         createTable(tableName: "work") {
             column(name: "w_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -576,103 +578,103 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-25") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-25") {
         addPrimaryKey(columnNames: "car_id", constraintName: "content_activation_recordPK", tableName: "content_activation_record")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-26") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-26") {
         addPrimaryKey(columnNames: "cs_id", constraintName: "coverage_statementPK", tableName: "coverage_statement")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-27") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-27") {
         addPrimaryKey(columnNames: "ent_id", constraintName: "entitlementPK", tableName: "entitlement")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-28") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-28") {
         addPrimaryKey(columnNames: "id", constraintName: "erm_resourcePK", tableName: "erm_resource")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-29") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-29") {
         addPrimaryKey(columnNames: "co_id", constraintName: "holdings_coveragePK", tableName: "holdings_coverage")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-30") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-30") {
         addPrimaryKey(columnNames: "id_id", constraintName: "identifierPK", tableName: "identifier")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-31") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-31") {
         addPrimaryKey(columnNames: "idns_id", constraintName: "identifier_namespacePK", tableName: "identifier_namespace")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-32") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-32") {
         addPrimaryKey(columnNames: "io_id", constraintName: "identifier_occurrencePK", tableName: "identifier_occurrence")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-33") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-33") {
         addPrimaryKey(columnNames: "ic_id", constraintName: "internal_contactPK", tableName: "internal_contact")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-34") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-34") {
         addPrimaryKey(columnNames: "nd_id", constraintName: "nodePK", tableName: "node")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-35") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-35") {
         addPrimaryKey(columnNames: "org_id", constraintName: "orgPK", tableName: "org")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-36") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-36") {
         addPrimaryKey(columnNames: "id", constraintName: "packagePK", tableName: "package")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-37") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-37") {
         addPrimaryKey(columnNames: "id", constraintName: "package_content_itemPK", tableName: "package_content_item")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-38") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-38") {
         addPrimaryKey(columnNames: "pt_id", constraintName: "platformPK", tableName: "platform")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-39") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-39") {
         addPrimaryKey(columnNames: "pl_id", constraintName: "platform_locatorPK", tableName: "platform_locator")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-40") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-40") {
         addPrimaryKey(columnNames: "id", constraintName: "platform_title_instancePK", tableName: "platform_title_instance")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-41") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-41") {
         addPrimaryKey(columnNames: "pop_id", constraintName: "po_line_proxyPK", tableName: "po_line_proxy")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-42") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-42") {
         addPrimaryKey(columnNames: "rdc_id", constraintName: "refdata_categoryPK", tableName: "refdata_category")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-43") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-43") {
         addPrimaryKey(columnNames: "rdv_id", constraintName: "refdata_valuePK", tableName: "refdata_value")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-44") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-44") {
         addPrimaryKey(columnNames: "rkb_id", constraintName: "remotekbPK", tableName: "remotekb")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-45") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-45") {
         addPrimaryKey(columnNames: "eh_id", constraintName: "sa_event_historyPK", tableName: "sa_event_history")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-46") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-46") {
         addPrimaryKey(columnNames: "sa_id", constraintName: "subscription_agreementPK", tableName: "subscription_agreement")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-47") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-47") {
         addPrimaryKey(columnNames: "id", constraintName: "title_instancePK", tableName: "title_instance")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-48") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-48") {
         addPrimaryKey(columnNames: "w_id", constraintName: "workPK", tableName: "work")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-49") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-49") {
         createIndex(indexName: "rdv_entry_idx", tableName: "refdata_value") {
             column(name: "rdv_value")
 
@@ -680,151 +682,151 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-50") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-50") {
         addForeignKeyConstraint(baseColumnNames: "io_identifier_fk", baseTableName: "identifier_occurrence", constraintName: "FK124sp9vc5hnix1ufo6wi2vbav", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id_id", referencedTableName: "identifier")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-51") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-51") {
         addForeignKeyConstraint(baseColumnNames: "cs_ti_fk", baseTableName: "coverage_statement", constraintName: "FK2ocimr1uh2pogta68xl9ph3n", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "title_instance")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-52") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-52") {
         addForeignKeyConstraint(baseColumnNames: "nd_parent", baseTableName: "node", constraintName: "FK2x99i2kqqt7g2ik5cn2fmif6t", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "nd_id", referencedTableName: "node")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-53") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-53") {
         addForeignKeyConstraint(baseColumnNames: "sa_renewal_priority", baseTableName: "subscription_agreement", constraintName: "FK34wtnrq42y7hiab2pg918y7en", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-54") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-54") {
         addForeignKeyConstraint(baseColumnNames: "sa_content_review_needed", baseTableName: "subscription_agreement", constraintName: "FK4nhteulih6q3nqtsu512ny93x", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-55") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-55") {
         addForeignKeyConstraint(baseColumnNames: "pci_pkg_fk", baseTableName: "package_content_item", constraintName: "FK4u9t780a3pgjy1wxsdn8r131k", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "package")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-56") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-56") {
         addForeignKeyConstraint(baseColumnNames: "sa_agreement_type", baseTableName: "subscription_agreement", constraintName: "FK613exmd4qa6bjjdycx9kot0yp", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-57") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-57") {
         addForeignKeyConstraint(baseColumnNames: "ti_work_fk", baseTableName: "title_instance", constraintName: "FK6jfb5y930akyqphqjt55yrga6", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "w_id", referencedTableName: "work")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-58") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-58") {
         addForeignKeyConstraint(baseColumnNames: "ic_role", baseTableName: "internal_contact", constraintName: "FK6njvotbglvhl7adk4hiv1kbsn", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-59") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-59") {
         addForeignKeyConstraint(baseColumnNames: "ic_owner_fk", baseTableName: "internal_contact", constraintName: "FK7p34rfl5q8gij3717gpkxq4yt", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "sa_id", referencedTableName: "subscription_agreement")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-60") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-60") {
         addForeignKeyConstraint(baseColumnNames: "co_ent_fk", baseTableName: "holdings_coverage", constraintName: "FK7tx1qaa6hcl1p5kg4n9k8fv4d", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "ent_id", referencedTableName: "entitlement")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-61") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-61") {
         addForeignKeyConstraint(baseColumnNames: "sa_is_perpetual", baseTableName: "subscription_agreement", constraintName: "FK8g7c4fgbop5kuy91di5eh9luq", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-62") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-62") {
         addForeignKeyConstraint(baseColumnNames: "pop_owner", baseTableName: "po_line_proxy", constraintName: "FK8ufrte3dhjhseabh067wg08lr", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "ent_id", referencedTableName: "entitlement")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-63") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-63") {
         addForeignKeyConstraint(baseColumnNames: "io_status_fk", baseTableName: "identifier_occurrence", constraintName: "FK930t3v9wtioa9a9j5013au5ci", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-64") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-64") {
         addForeignKeyConstraint(baseColumnNames: "eh_event_outcome", baseTableName: "sa_event_history", constraintName: "FK9hxymcjll2kctbwvm60j8ywxv", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-65") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-65") {
         addForeignKeyConstraint(baseColumnNames: "car_target_kb_fk", baseTableName: "content_activation_record", constraintName: "FK9l1k430yfqn9hft2a27kvrv12", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rkb_id", referencedTableName: "remotekb")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-66") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-66") {
         addForeignKeyConstraint(baseColumnNames: "ent_resource_fk", baseTableName: "entitlement", constraintName: "FK9uj3dokm2wv87kfp3vjphnc83", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "erm_resource")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-67") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-67") {
         addForeignKeyConstraint(baseColumnNames: "io_ti_fk", baseTableName: "identifier_occurrence", constraintName: "FKat7yej3qg0w5ppb0t4akj51wl", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "title_instance")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-68") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-68") {
         addForeignKeyConstraint(baseColumnNames: "id_ns_fk", baseTableName: "identifier", constraintName: "FKby5jjtajics8edtt193lwtnwv", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "idns_id", referencedTableName: "identifier_namespace")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-69") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-69") {
         addForeignKeyConstraint(baseColumnNames: "car_pti_fk", baseTableName: "content_activation_record", constraintName: "FKcg8khs1ip5xiibdkp85xoe7ba", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "platform_title_instance")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-70") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-70") {
         addForeignKeyConstraint(baseColumnNames: "cs_pci_fk", baseTableName: "coverage_statement", constraintName: "FKciqq54dwgdmv0ta5ugs58sn36", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "package_content_item")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-71") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-71") {
         addForeignKeyConstraint(baseColumnNames: "cs_pti_fk", baseTableName: "coverage_statement", constraintName: "FKdj82640bdcj4dfrbn0aqdgbfp", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "platform_title_instance")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-72") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-72") {
         addForeignKeyConstraint(baseColumnNames: "pti_ti_fk", baseTableName: "platform_title_instance", constraintName: "FKedoadk035beg5u3vi2232pq9m", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "title_instance")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-73") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-73") {
         addForeignKeyConstraint(baseColumnNames: "res_type_fk", baseTableName: "erm_resource", constraintName: "FKef3ae6ct52nn3jcmqidhhpwf8", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-74") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-74") {
         addForeignKeyConstraint(baseColumnNames: "eh_owner", baseTableName: "sa_event_history", constraintName: "FKeopwa26u1tipqav4a0y01i9sr", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "sa_id", referencedTableName: "subscription_agreement")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-75") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-75") {
         addForeignKeyConstraint(baseColumnNames: "res_sub_type_fk", baseTableName: "erm_resource", constraintName: "FKfc1lm4f2parkaa8en9fmo4sqc", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-76") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-76") {
         addForeignKeyConstraint(baseColumnNames: "pl_owner_fk", baseTableName: "platform_locator", constraintName: "FKfn4ls5f77sc18cq9c8owlkgtp", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "pt_id", referencedTableName: "platform")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-77") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-77") {
         addForeignKeyConstraint(baseColumnNames: "rdv_owner", baseTableName: "refdata_value", constraintName: "FKh4fon2a7k4y8b2sicjm0i6oy8", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdc_id", referencedTableName: "refdata_category")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-78") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-78") {
         addForeignKeyConstraint(baseColumnNames: "sa_agreement_status", baseTableName: "subscription_agreement", constraintName: "FKiivriw3306iouwpg8e65t3ff0", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-79") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-79") {
         addForeignKeyConstraint(baseColumnNames: "pkg_remote_kb", baseTableName: "package", constraintName: "FKoedx99aeb9ll9v1p7w29htqtl", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rkb_id", referencedTableName: "remotekb")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-80") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-80") {
         addForeignKeyConstraint(baseColumnNames: "pkg_vendor_fk", baseTableName: "package", constraintName: "FKokps4xbl6ipd7unkfq910jn03", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "org_id", referencedTableName: "org")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-81") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-81") {
         addForeignKeyConstraint(baseColumnNames: "ent_owner_fk", baseTableName: "entitlement", constraintName: "FKoocrauwiw6xp7ace0yueywgqy", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "sa_id", referencedTableName: "subscription_agreement")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-82") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-82") {
         addForeignKeyConstraint(baseColumnNames: "pci_pti_fk", baseTableName: "package_content_item", constraintName: "FKostrwqec52cid7enxbr4b2loe", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "platform_title_instance")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-83") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-83") {
         addForeignKeyConstraint(baseColumnNames: "sa_vendor_fk", baseTableName: "subscription_agreement", constraintName: "FKppeugnj4xts3ah8tjmeg232db", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "org_id", referencedTableName: "org")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-84") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-84") {
         addForeignKeyConstraint(baseColumnNames: "eh_event_type", baseTableName: "sa_event_history", constraintName: "FKs8nxucxkesrpshhxsh15wxdn0", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-85") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-85") {
         addForeignKeyConstraint(baseColumnNames: "pkg_nominal_platform_fk", baseTableName: "package", constraintName: "FKtji5rpd3emxprdidedl006f9u", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "pt_id", referencedTableName: "platform")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1539514444652-86") {
+    changeSet(author: "ibbo (generated)", id: "1539598010676-86") {
         addForeignKeyConstraint(baseColumnNames: "pti_pt_fk", baseTableName: "platform_title_instance", constraintName: "FKtlecp40x0sb3rd9w4qi16lcu0", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "pt_id", referencedTableName: "platform")
     }
 }

--- a/service/grails-app/migrations/initial-model.groovy
+++ b/service/grails-app/migrations/initial-model.groovy
@@ -1,6 +1,6 @@
 databaseChangeLog = {
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-1") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-1") {
         createTable(tableName: "content_activation_target") {
             column(name: "car_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -28,7 +28,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-2") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-2") {
         createTable(tableName: "coverage_statement") {
             column(name: "cs_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -58,7 +58,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-3") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-3") {
         createTable(tableName: "entitlement") {
             column(name: "ent_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -82,7 +82,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-4") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-4") {
         createTable(tableName: "erm_resource") {
             column(name: "id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -100,7 +100,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-5") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-5") {
         createTable(tableName: "holdings_coverage") {
             column(name: "co_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -126,7 +126,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-6") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-6") {
         createTable(tableName: "identifier") {
             column(name: "id_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -146,7 +146,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-7") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-7") {
         createTable(tableName: "identifier_namespace") {
             column(name: "idns_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -162,7 +162,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-8") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-8") {
         createTable(tableName: "identifier_occurrence") {
             column(name: "io_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -184,7 +184,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-9") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-9") {
         createTable(tableName: "internal_contact") {
             column(name: "ic_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -208,7 +208,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-10") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-10") {
         createTable(tableName: "node") {
             column(name: "nd_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -238,7 +238,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-11") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-11") {
         createTable(tableName: "org") {
             column(name: "org_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -258,7 +258,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-12") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-12") {
         createTable(tableName: "package") {
             column(name: "id", type: "VARCHAR(255)") {
                 constraints(nullable: "false")
@@ -280,7 +280,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-13") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-13") {
         createTable(tableName: "package_content_item") {
             column(name: "id", type: "VARCHAR(255)") {
                 constraints(nullable: "false")
@@ -310,7 +310,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-14") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-14") {
         createTable(tableName: "platform") {
             column(name: "pt_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -326,7 +326,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-15") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-15") {
         createTable(tableName: "platform_locator") {
             column(name: "pl_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -346,7 +346,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-16") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-16") {
         createTable(tableName: "platform_title_instance") {
             column(name: "id", type: "VARCHAR(255)") {
                 constraints(nullable: "false")
@@ -364,7 +364,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-17") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-17") {
         createTable(tableName: "po_line_proxy") {
             column(name: "pop_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -386,7 +386,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-18") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-18") {
         createTable(tableName: "refdata_category") {
             column(name: "rdc_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -402,7 +402,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-19") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-19") {
         createTable(tableName: "refdata_value") {
             column(name: "rdv_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -426,7 +426,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-20") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-20") {
         createTable(tableName: "remotekb") {
             column(name: "rkb_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -468,7 +468,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-21") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-21") {
         createTable(tableName: "sa_event_history") {
             column(name: "eh_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -504,7 +504,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-22") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-22") {
         createTable(tableName: "subscription_agreement") {
             column(name: "sa_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -550,7 +550,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-23") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-23") {
         createTable(tableName: "title_instance") {
             column(name: "id", type: "VARCHAR(255)") {
                 constraints(nullable: "false")
@@ -560,7 +560,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-24") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-24") {
         createTable(tableName: "work") {
             column(name: "w_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -576,103 +576,103 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-25") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-25") {
         addPrimaryKey(columnNames: "car_id", constraintName: "content_activation_targetPK", tableName: "content_activation_target")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-26") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-26") {
         addPrimaryKey(columnNames: "cs_id", constraintName: "coverage_statementPK", tableName: "coverage_statement")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-27") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-27") {
         addPrimaryKey(columnNames: "ent_id", constraintName: "entitlementPK", tableName: "entitlement")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-28") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-28") {
         addPrimaryKey(columnNames: "id", constraintName: "erm_resourcePK", tableName: "erm_resource")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-29") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-29") {
         addPrimaryKey(columnNames: "co_id", constraintName: "holdings_coveragePK", tableName: "holdings_coverage")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-30") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-30") {
         addPrimaryKey(columnNames: "id_id", constraintName: "identifierPK", tableName: "identifier")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-31") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-31") {
         addPrimaryKey(columnNames: "idns_id", constraintName: "identifier_namespacePK", tableName: "identifier_namespace")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-32") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-32") {
         addPrimaryKey(columnNames: "io_id", constraintName: "identifier_occurrencePK", tableName: "identifier_occurrence")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-33") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-33") {
         addPrimaryKey(columnNames: "ic_id", constraintName: "internal_contactPK", tableName: "internal_contact")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-34") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-34") {
         addPrimaryKey(columnNames: "nd_id", constraintName: "nodePK", tableName: "node")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-35") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-35") {
         addPrimaryKey(columnNames: "org_id", constraintName: "orgPK", tableName: "org")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-36") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-36") {
         addPrimaryKey(columnNames: "id", constraintName: "packagePK", tableName: "package")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-37") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-37") {
         addPrimaryKey(columnNames: "id", constraintName: "package_content_itemPK", tableName: "package_content_item")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-38") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-38") {
         addPrimaryKey(columnNames: "pt_id", constraintName: "platformPK", tableName: "platform")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-39") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-39") {
         addPrimaryKey(columnNames: "pl_id", constraintName: "platform_locatorPK", tableName: "platform_locator")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-40") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-40") {
         addPrimaryKey(columnNames: "id", constraintName: "platform_title_instancePK", tableName: "platform_title_instance")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-41") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-41") {
         addPrimaryKey(columnNames: "pop_id", constraintName: "po_line_proxyPK", tableName: "po_line_proxy")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-42") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-42") {
         addPrimaryKey(columnNames: "rdc_id", constraintName: "refdata_categoryPK", tableName: "refdata_category")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-43") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-43") {
         addPrimaryKey(columnNames: "rdv_id", constraintName: "refdata_valuePK", tableName: "refdata_value")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-44") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-44") {
         addPrimaryKey(columnNames: "rkb_id", constraintName: "remotekbPK", tableName: "remotekb")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-45") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-45") {
         addPrimaryKey(columnNames: "eh_id", constraintName: "sa_event_historyPK", tableName: "sa_event_history")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-46") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-46") {
         addPrimaryKey(columnNames: "sa_id", constraintName: "subscription_agreementPK", tableName: "subscription_agreement")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-47") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-47") {
         addPrimaryKey(columnNames: "id", constraintName: "title_instancePK", tableName: "title_instance")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-48") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-48") {
         addPrimaryKey(columnNames: "w_id", constraintName: "workPK", tableName: "work")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-49") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-49") {
         createIndex(indexName: "rdv_entry_idx", tableName: "refdata_value") {
             column(name: "rdv_value")
 
@@ -680,151 +680,151 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-50") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-50") {
         addForeignKeyConstraint(baseColumnNames: "io_identifier_fk", baseTableName: "identifier_occurrence", constraintName: "FK124sp9vc5hnix1ufo6wi2vbav", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id_id", referencedTableName: "identifier")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-51") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-51") {
         addForeignKeyConstraint(baseColumnNames: "cs_ti_fk", baseTableName: "coverage_statement", constraintName: "FK2ocimr1uh2pogta68xl9ph3n", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "title_instance")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-52") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-52") {
         addForeignKeyConstraint(baseColumnNames: "nd_parent", baseTableName: "node", constraintName: "FK2x99i2kqqt7g2ik5cn2fmif6t", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "nd_id", referencedTableName: "node")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-53") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-53") {
         addForeignKeyConstraint(baseColumnNames: "sa_renewal_priority", baseTableName: "subscription_agreement", constraintName: "FK34wtnrq42y7hiab2pg918y7en", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-54") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-54") {
         addForeignKeyConstraint(baseColumnNames: "sa_content_review_needed", baseTableName: "subscription_agreement", constraintName: "FK4nhteulih6q3nqtsu512ny93x", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-55") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-55") {
         addForeignKeyConstraint(baseColumnNames: "pci_pkg_fk", baseTableName: "package_content_item", constraintName: "FK4u9t780a3pgjy1wxsdn8r131k", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "package")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-56") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-56") {
         addForeignKeyConstraint(baseColumnNames: "sa_agreement_type", baseTableName: "subscription_agreement", constraintName: "FK613exmd4qa6bjjdycx9kot0yp", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-57") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-57") {
         addForeignKeyConstraint(baseColumnNames: "ti_work_fk", baseTableName: "title_instance", constraintName: "FK6jfb5y930akyqphqjt55yrga6", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "w_id", referencedTableName: "work")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-58") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-58") {
         addForeignKeyConstraint(baseColumnNames: "ic_role", baseTableName: "internal_contact", constraintName: "FK6njvotbglvhl7adk4hiv1kbsn", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-59") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-59") {
         addForeignKeyConstraint(baseColumnNames: "ic_owner_fk", baseTableName: "internal_contact", constraintName: "FK7p34rfl5q8gij3717gpkxq4yt", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "sa_id", referencedTableName: "subscription_agreement")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-60") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-60") {
         addForeignKeyConstraint(baseColumnNames: "co_ent_fk", baseTableName: "holdings_coverage", constraintName: "FK7tx1qaa6hcl1p5kg4n9k8fv4d", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "ent_id", referencedTableName: "entitlement")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-61") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-61") {
         addForeignKeyConstraint(baseColumnNames: "sa_is_perpetual", baseTableName: "subscription_agreement", constraintName: "FK8g7c4fgbop5kuy91di5eh9luq", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-62") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-62") {
         addForeignKeyConstraint(baseColumnNames: "pop_owner", baseTableName: "po_line_proxy", constraintName: "FK8ufrte3dhjhseabh067wg08lr", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "ent_id", referencedTableName: "entitlement")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-63") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-63") {
         addForeignKeyConstraint(baseColumnNames: "io_status_fk", baseTableName: "identifier_occurrence", constraintName: "FK930t3v9wtioa9a9j5013au5ci", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-64") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-64") {
         addForeignKeyConstraint(baseColumnNames: "eh_event_outcome", baseTableName: "sa_event_history", constraintName: "FK9hxymcjll2kctbwvm60j8ywxv", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-65") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-65") {
         addForeignKeyConstraint(baseColumnNames: "ent_resource_fk", baseTableName: "entitlement", constraintName: "FK9uj3dokm2wv87kfp3vjphnc83", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "erm_resource")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-66") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-66") {
         addForeignKeyConstraint(baseColumnNames: "io_ti_fk", baseTableName: "identifier_occurrence", constraintName: "FKat7yej3qg0w5ppb0t4akj51wl", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "title_instance")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-67") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-67") {
         addForeignKeyConstraint(baseColumnNames: "id_ns_fk", baseTableName: "identifier", constraintName: "FKby5jjtajics8edtt193lwtnwv", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "idns_id", referencedTableName: "identifier_namespace")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-68") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-68") {
         addForeignKeyConstraint(baseColumnNames: "car_pti_fk", baseTableName: "content_activation_target", constraintName: "FKbyr8417ulw3vjwb3qp3pr13c2", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "platform_title_instance")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-69") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-69") {
         addForeignKeyConstraint(baseColumnNames: "cs_pci_fk", baseTableName: "coverage_statement", constraintName: "FKciqq54dwgdmv0ta5ugs58sn36", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "package_content_item")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-70") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-70") {
         addForeignKeyConstraint(baseColumnNames: "cs_pti_fk", baseTableName: "coverage_statement", constraintName: "FKdj82640bdcj4dfrbn0aqdgbfp", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "platform_title_instance")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-71") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-71") {
         addForeignKeyConstraint(baseColumnNames: "pti_ti_fk", baseTableName: "platform_title_instance", constraintName: "FKedoadk035beg5u3vi2232pq9m", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "title_instance")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-72") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-72") {
         addForeignKeyConstraint(baseColumnNames: "res_type_fk", baseTableName: "erm_resource", constraintName: "FKef3ae6ct52nn3jcmqidhhpwf8", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-73") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-73") {
         addForeignKeyConstraint(baseColumnNames: "eh_owner", baseTableName: "sa_event_history", constraintName: "FKeopwa26u1tipqav4a0y01i9sr", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "sa_id", referencedTableName: "subscription_agreement")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-74") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-74") {
         addForeignKeyConstraint(baseColumnNames: "res_sub_type_fk", baseTableName: "erm_resource", constraintName: "FKfc1lm4f2parkaa8en9fmo4sqc", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-75") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-75") {
         addForeignKeyConstraint(baseColumnNames: "pl_owner_fk", baseTableName: "platform_locator", constraintName: "FKfn4ls5f77sc18cq9c8owlkgtp", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "pt_id", referencedTableName: "platform")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-76") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-76") {
         addForeignKeyConstraint(baseColumnNames: "rdv_owner", baseTableName: "refdata_value", constraintName: "FKh4fon2a7k4y8b2sicjm0i6oy8", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdc_id", referencedTableName: "refdata_category")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-77") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-77") {
         addForeignKeyConstraint(baseColumnNames: "sa_agreement_status", baseTableName: "subscription_agreement", constraintName: "FKiivriw3306iouwpg8e65t3ff0", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-78") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-78") {
         addForeignKeyConstraint(baseColumnNames: "car_target_kb_fk", baseTableName: "content_activation_target", constraintName: "FKj7orcapekjyxir8xukrynibc4", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rkb_id", referencedTableName: "remotekb")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-79") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-79") {
         addForeignKeyConstraint(baseColumnNames: "pkg_remote_kb", baseTableName: "package", constraintName: "FKoedx99aeb9ll9v1p7w29htqtl", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rkb_id", referencedTableName: "remotekb")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-80") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-80") {
         addForeignKeyConstraint(baseColumnNames: "pkg_vendor_fk", baseTableName: "package", constraintName: "FKokps4xbl6ipd7unkfq910jn03", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "org_id", referencedTableName: "org")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-81") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-81") {
         addForeignKeyConstraint(baseColumnNames: "ent_owner_fk", baseTableName: "entitlement", constraintName: "FKoocrauwiw6xp7ace0yueywgqy", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "sa_id", referencedTableName: "subscription_agreement")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-82") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-82") {
         addForeignKeyConstraint(baseColumnNames: "pci_pti_fk", baseTableName: "package_content_item", constraintName: "FKostrwqec52cid7enxbr4b2loe", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "platform_title_instance")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-83") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-83") {
         addForeignKeyConstraint(baseColumnNames: "sa_vendor_fk", baseTableName: "subscription_agreement", constraintName: "FKppeugnj4xts3ah8tjmeg232db", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "org_id", referencedTableName: "org")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-84") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-84") {
         addForeignKeyConstraint(baseColumnNames: "eh_event_type", baseTableName: "sa_event_history", constraintName: "FKs8nxucxkesrpshhxsh15wxdn0", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-85") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-85") {
         addForeignKeyConstraint(baseColumnNames: "pkg_nominal_platform_fk", baseTableName: "package", constraintName: "FKtji5rpd3emxprdidedl006f9u", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "pt_id", referencedTableName: "platform")
     }
 
-    changeSet(author: "ibbo (generated)", id: "1539343607002-86") {
+    changeSet(author: "ianibbo (generated)", id: "1539513591756-86") {
         addForeignKeyConstraint(baseColumnNames: "pti_pt_fk", baseTableName: "platform_title_instance", constraintName: "FKtlecp40x0sb3rd9w4qi16lcu0", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "pt_id", referencedTableName: "platform")
     }
 }

--- a/service/grails-app/services/org/olf/PackageIngestService.groovy
+++ b/service/grails-app/services/org/olf/PackageIngestService.groovy
@@ -59,8 +59,12 @@ public class PackageIngestService {
     def pkg = Pkg.findBySourceAndReference(package_data.header.packageSource, package_data.header.packageSlug)
 
     def vendor = null;
-    if ( package_data.header?.packageProvider?.name ) {
+    if ( ( package_data.header?.packageProvider?.name != null ) && ( package_data.header?.packageProvider?.name.trim().length() > 0 ) ) {
       vendor = dependentServiceProxyService.coordinateOrg(package_data.header?.packageProvider?.name)
+      vendor.enrich(['reference':package_data.header?.packageProvider?.reference]);
+    }
+    else {
+      log.warn('Package ingest - no provider information present');
     }
 
     if ( pkg == null ) {


### PR DESCRIPTION
Add org.reference as a general field which is temporarily being used to hold EKB vendor.id when wanting to do content activation in EKB. Expect this to be moved to a custom property like EKBVendorId in the near future, but reference a perfectly good temporary holding position.