### PR TITLE
project name should be set from the property appName.

### DIFF
--- a/service/settings.gradle
+++ b/service/settings.gradle
@@ -1,4 +1,4 @@
-rootProject.name = 'olf-erm'
+rootProject.name = "${appName}"
 
 // Check for local file too. File should be at same level as this file and named "_settings.gradle"
 File localSettings = new File(rootProject.projectDir, './_settings.gradle')


### PR DESCRIPTION
Ensure gradle property appName is honoured and can therefore be overridden at build time.