### PR TITLE
All mod-erm to FOLIO CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,10 +46,6 @@ pipeline {
               env.dockerRepo = 'folioci'
               env.version = "${gradleVersion}-SNAPSHOT.${env.BUILD_NUMBER}"
             }
-            // debug
-            echo "$env.version"
-            echo "$env.dockerRepo"
-
           }
         }
         sendNotifications 'STARTED'  
@@ -84,6 +80,7 @@ pipeline {
       steps {
         script {
           docker.withRegistry('https://index.docker.io/v1/', 'DockerHubIDJenkins') {
+            sh "docker tag ${env.dockerRepo}/${env.name}:${env.version} ${env.dockerRepo}/${env.name}:latest"
             sh "docker push ${env.dockerRepo}/${env.name}:${env.version}"
             sh "docker push ${env.dockerRepo}/${env.name}:latest"
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,9 +28,6 @@ pipeline {
             def foliociLib = new org.folio.foliociCommands()
             def gradleVersion = foliociLib.gradleProperty('appVersion')
 
-            // debug
-            echo "$gradleVersion
-
             env.name = env.ORG_GRADLE_PROJECT_appName
         
             // if release 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,6 +41,7 @@ pipeline {
               else { 
                 error('Git release tag and Maven version mismatch')
               }
+            }
             else {
               env.dockerRepo = 'folioci'
               env.version = "${gradleVersion}-SNAPSHOT.${env.BUILD_NUMBER}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,7 @@ pipeline {
             }
             else {
               env.dockerRepo = 'folioci'
-              env.version = "${gradleVersion}-SNAPSHOT.${env.BUILD_NUMBER}
+              env.version = "${gradleVersion}-SNAPSHOT.${env.BUILD_NUMBER}"
             }
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,7 +50,7 @@ pipeline {
     stage('Gradle Build') { 
       steps {
         dir(env.BUILD_DIR) {
-          sh "./gradlew $env.GRADLE_OPTS -PappVersion=${env.version} assemble
+          sh "./gradlew $env.GRADLE_OPTS -PappVersion=${env.version} assemble"
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,13 +69,15 @@ pipeline {
       when { 
         anyOf {
           branch 'master'
-          environment name: isRelease, value: true 
+          expression { return env.isRelease }
         }
       }
       steps {
-        docker.withRegistry('https://index.docker.io/v1/', 'DockerHubIDJenkins') {
-          sh "docker push ${env.dockerRepo}/${env.name}:${env.version}"
-          sh "docker push ${env.dockerRepo}/${env.name}:latest"
+        script {
+          docker.withRegistry('https://index.docker.io/v1/', 'DockerHubIDJenkins') {
+            sh "docker push ${env.dockerRepo}/${env.name}:${env.version}"
+            sh "docker push ${env.dockerRepo}/${env.name}:latest"
+          }
         }
       }
     }
@@ -84,7 +86,7 @@ pipeline {
       when {
         anyOf { 
           branch 'master'
-          environment name: isRelease, value: true
+          expression { return env.isRelease }
         }
       }
       steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,109 @@
+@Library ('folio_jenkins_shared_libs') _
+
+pipeline {
+
+  environment {
+    ORG_GRADLE_PROJECT_appName = 'mod-erm'
+    GRADLE_OPTS = '--console plain --no-daemon'
+    BUILD_DIR = "${env.WORKSPACE}/service"
+    MD = "${env.WORKSPACE}/service/build/resources/main/okapi/ModuleDescriptor.json"
+  }
+
+  options {
+    timeout(30)
+    buildDiscarder(logRotator(numToKeepStr: '30'))
+  }
+
+  agent {
+    node {
+      label 'jenkins-slave-all'
+    }
+  }
+
+  stages {
+    stage ('Setup') {
+      steps {
+        script {
+          def foliociLib = new org.folio.foliociCommands()
+          def gradleVersion = foliociLib.gradleProperty('appVersion')
+
+          env.name = env.ORG_GRADLE_PROJECT_appName
+        
+          // if release 
+          if ( foliociLib.isRelease() ) {
+            // make sure git tag and version match
+            if ( foliociLib.tagMatch(version) ) {
+              env.isRelease = true 
+              env.dockerRepo = 'folioorg'
+              env.version = gradleVersion
+            }
+            else {
+              env.dockerRepo = 'folioci'
+              env.version = "${gradleVersion}-SNAPSHOT.${env.BUILD_NUMBER}
+            }
+          }
+        }
+        sendNotifications 'STARTED'  
+      }
+    }
+
+    stage('Gradle Build') { 
+      steps {
+        dir(env.BUILD_DIR) {
+          sh "./gradlew $env.GRADLE_OPTS -PappVersion=${env.version} assemble
+        }
+      }
+    }
+   
+    stage('Build Docker') {
+      steps {
+        dir(env.BUILD_DIR) {
+          sh "./gradlew $env.GRADLE_OPTS -PappVersion=${env.version} -PdockerRepo=${env.dockerRepo} buildImage"
+        }
+        // debug
+        sh "cat $env.MD"
+      } 
+    }
+
+    stage('Publish Docker Image') { 
+      when { 
+        anyOf {
+          branch 'master'
+          environment name: isRelease, value: true 
+        }
+      }
+      steps {
+        docker.withRegistry('https://index.docker.io/v1/', 'DockerHubIDJenkins') {
+          sh "docker push ${env.dockerRepo}/${env.name}:${env.version}"
+          sh "docker push ${env.dockerRepo}/${env.name}:latest"
+        }
+      }
+    }
+
+    stage('Publish Module Descriptor') {
+      when {
+        anyOf { 
+          branch 'master'
+          environment name: isRelease, value: true
+        }
+      }
+      steps {
+        script {
+          def foliociLib = new org.folio.foliociCommands()
+          foliociLib.updateModDescriptor(env.MD) 
+        }
+        postModuleDescriptor(env.MD)
+      }
+    }
+
+  } // end stages
+
+  post {
+    always {
+      dockerCleanup()
+      sendNotifications currentBuild.result 
+    }
+  }
+}
+         
+

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,6 +28,9 @@ pipeline {
             def foliociLib = new org.folio.foliociCommands()
             def gradleVersion = foliociLib.gradleProperty('appVersion')
 
+            // debug
+            echo "$gradleVersion
+
             env.name = env.ORG_GRADLE_PROJECT_appName
         
             // if release 
@@ -43,6 +46,12 @@ pipeline {
                 env.version = "${gradleVersion}-SNAPSHOT.${env.BUILD_NUMBER}"
               }
             }
+            // debug
+            echo "$gradleVersion"
+            echo "$env.dockerRepo"
+            
+
+
           }
         }
         sendNotifications 'STARTED'  

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,16 +38,16 @@ pipeline {
                 env.dockerRepo = 'folioorg'
                 env.version = gradleVersion
               }
-              else {
-                env.dockerRepo = 'folioci'
-                env.version = "${gradleVersion}-SNAPSHOT.${env.BUILD_NUMBER}"
+              else { 
+                error('Git release tag and Maven version mismatch')
               }
+            else {
+              env.dockerRepo = 'folioci'
+              env.version = "${gradleVersion}-SNAPSHOT.${env.BUILD_NUMBER}"
             }
             // debug
-            echo "$gradleVersion"
+            echo "$env.version"
             echo "$env.dockerRepo"
-            
-
 
           }
         }

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -238,7 +238,8 @@ import com.bmuschko.gradle.docker.tasks.image.Dockerfile
 import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
 
 ext {
-  dockerTag = "${project.dockerRepo}/${project.name}:${project.version}${dockerTagSuffix}".toLowerCase()
+  // dockerTag = "${project.dockerRepo}/${project.name}:${project.version}${dockerTagSuffix}".toLowerCase()
+  dockerTag = "${project.dockerRepo}/${project.name}:${project.version}${dockerTagSuffix}"
   dockerBuildDir = mkdir("${buildDir}/docker")
 }
 

--- a/service/src/main/okapi/ModuleDescriptor-template.json
+++ b/service/src/main/okapi/ModuleDescriptor-template.json
@@ -155,5 +155,12 @@
         "vendor_category.item.get"
       ]
     }
-  ]
+  ],
+  "launchDescriptor": {
+    "dockerImage": "${info.app.name}:${info.app.version}",
+    "dockerArgs": {
+      "HostConfig": { "PortBindings": { "8080/tcp":  [{ "HostPort": "%p" }] } }
+    },
+    "dockerPull" : false
+  }
 }


### PR DESCRIPTION
* Added custom Jenkinsfile for FOLIO CI
* Don't covert docker image name to lower case.   The 'id' field in the module descriptor needs to match the docker image name (and case). 
* Add a launch descriptor to the module descriptor template.  This is needed for deployment to FOLIO testing environment. 

TODO in a future PR.   Add ability to provision an Okapi and Postgres instance during the build to run the integration tests. 