### PR TITLE
update interface name and version

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -14,7 +14,7 @@ buildscript {
 }
 
 
-final String version_regex = /^(((\d+)\.\d+)\.\d+)(-([a-z]+[\w]*))?$/
+final String version_regex = /^(((\d+)\.\d+)\.\d+)(-([a-zA-Z]+\.\d+))?$/
 version "${appVersion}"
 group "org.olf"
 

--- a/service/src/main/okapi/ModuleDescriptor-template.json
+++ b/service/src/main/okapi/ModuleDescriptor-template.json
@@ -3,8 +3,8 @@
   "name": "${info.app.name}",
   "provides": [
     {
-      "id": "olf-erm",
-      "version": "1.0",
+      "id": "erm",
+      "version": "${info.app.minorVersion}",
       "handlers" : [
         {
           "methods": ["GET", "POST"],

--- a/service/src/main/okapi/ModuleDescriptor-template.json
+++ b/service/src/main/okapi/ModuleDescriptor-template.json
@@ -3,8 +3,8 @@
   "name": "${info.app.name}",
   "provides": [
     {
-      "id": "${info.app.name}",
-      "version": "${info.app.minorVersion}",
+      "id": "olf-erm",
+      "version": "1.0",
       "handlers" : [
         {
           "methods": ["GET", "POST"],


### PR DESCRIPTION
The interface name and interface version specified in the module descriptor should be distinct from the module name and version.    An interface can be independent of a module .  Also, I don't think you want to increment the interface version each time a new version of the module is released (snapshot or release version).  Probably should only be changed when the interface has changed.

